### PR TITLE
multiline support for secondary_info

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -173,6 +173,9 @@ class TemplateEntityRow extends LitElement {
         #wrapper.hidden {
           display: none;
         }
+        #wrapper .info.pointer .secondary {
+          white-space: pre;
+        }        
         #staging {
           display: none;
         }


### PR DESCRIPTION
Added multiline support for secondary_info:
https://github.com/thomasloven/lovelace-template-entity-row/issues/71
